### PR TITLE
Mejorado el contraste del título con la imagen destacada en grid style2

### DIFF
--- a/style.css
+++ b/style.css
@@ -108,3 +108,18 @@
 	background-color: #fff;
 	text-align: initial;
 }
+
+.vl-middle-block.style2 .vl-grid-block .vl-post-content {
+	padding: 20px 15px 10px;
+	background: -moz-linear-gradient(top,rgba(0,0,0,0) 0%,rgba(0,0,0,.8) 100%);
+	background: -webkit-gradient(linear,left top,left bottom,color-stop(0%,rgba(0,0,0,0)),color-stop(100%,rgba(0,0,0,.8)));
+	background: -webkit-linear-gradient(top,rgba(0,0,0,0) 0%,rgba(0,0,0,.8) 100%);
+	background: -o-linear-gradient(top,rgba(0,0,0,0) 0%,rgba(0,0,0,.8) 100%);
+	background: -ms-linear-gradient(top,rgba(0,0,0,0) 0%,rgba(0,0,0,.8) 100%);
+	background: linear-gradient(to bottom,rgba(0,0,0,0) 0%,rgba(0,0,0,.8) 100%);
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#b3000000', GradientType=0);
+}
+
+.vl-middle-block.style2 h3 {
+	text-shadow: 0.07em 0 rgba(0, 0, 0, 0.15), 0 0.07em rgba(0, 0, 0, 0.15), -0.07em 0 rgba(0, 0, 0, 0.15), 0 -0.07em rgba(0, 0, 0, 0.15);
+}


### PR DESCRIPTION
El segundo tipo de bloque para contenidos presenta el título del post sobreimpreso sobre la imagen del mismo. Cuando la imagen es muy clara o tiene texto blanco no se puede leer correctamente el texto. Aumentado el degradé de la imagen y agregada sombra al texto para mejorar contraste.